### PR TITLE
Fix pipe captures

### DIFF
--- a/Syntaxes/R.plist
+++ b/Syntaxes/R.plist
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(=|&lt;-|&lt;&lt;-|-&gt;|-&gt;&gt;)</string>
+			<string>(=|&lt;-|&lt;&lt;-|-&gt;|-&gt;&gt;|%&gt;%|\|&gt;)</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.r</string>
 		</dict>


### PR DESCRIPTION
Should capture the `%>%` and `|>` additions in R 4+.